### PR TITLE
Fix memory leak in __rtnl_talk_iov()

### DIFF
--- a/lib/libnetlink.c
+++ b/lib/libnetlink.c
@@ -999,14 +999,19 @@ next:
 						rtnl_talk_error(h, err, errfn);
 				}
 
+				if (i < iovlen) {
+					free(buf);
+					goto next;
+				}
+
+				if (error) {
+					free(buf);
+					return -i;
+				}
+
 				if (answer)
 					*answer = (struct nlmsghdr *)buf;
-				else
-					free(buf);
-
-				if (i < iovlen)
-					goto next;
-				return error ? -i : 0;
+				return 0;
 			}
 
 			if (answer) {


### PR DESCRIPTION
If `__rtnl_talk_iov()` fails then callers are not expected to free `answer`.

Currently if `NLMSG_ERROR` was received with an error then the netlink buffer was stored in `answer`, while still returning an error